### PR TITLE
Use meaningful variables

### DIFF
--- a/src/Command/UnusedCommand.php
+++ b/src/Command/UnusedCommand.php
@@ -166,33 +166,33 @@ class UnusedCommand extends BaseCommand
             $composer->getPackage()->getDevAutoload()
         );
 
-        $paths = [];
+        $autoloadDirs = [];
         $autoloadFiles = [];
 
         foreach ($autoload as $autoloadType => $namespaces) {
-            foreach ($namespaces as $namespace => $dirs) {
-                if (!is_array($dirs)) {
-                    $dirs = [$dirs];
+            foreach ($namespaces as $namespace => $paths) {
+                if (!is_array($paths)) {
+                    $paths = [$paths];
                 }
 
-                foreach ($dirs as $dir) {
-                    $resolvePath = stream_resolve_include_path($dir);
+                foreach ($paths as $path) {
+                    $resolvePath = stream_resolve_include_path($path);
 
                     if (!$resolvePath) {
                         continue;
                     }
 
-                    if (in_array($autoloadType, ['classmap', 'files']) && is_file($dir)) {
-                        $autoloadFiles[] = new SplFileInfo($dir, pathinfo($dir, PATHINFO_DIRNAME), $dir);
+                    if (in_array($autoloadType, ['classmap', 'files']) && is_file($path)) {
+                        $autoloadFiles[] = new SplFileInfo($path, pathinfo($path, PATHINFO_DIRNAME), $path);
                         continue;
                     }
 
-                    $paths[] = $resolvePath;
+                    $autoloadDirs[] = $resolvePath;
                 }
             }
         }
 
-        if (empty($paths)) {
+        if (empty($autoloadDirs) && empty($autoloadFiles)) {
             $io->error('Could not load paths from root package to scan.');
 
             return [];
@@ -200,7 +200,7 @@ class UnusedCommand extends BaseCommand
 
         $finder = new Finder();
         /** @var SplFileInfo[] $files */
-        $files = $finder->files()->name('*.php')->in($paths)->append($autoloadFiles);
+        $files = $finder->files()->name('*.php')->in($autoloadDirs)->append($autoloadFiles);
 
         $parser = (new ParserFactory())->create(ParserFactory::ONLY_PHP7);
         $visitor = new NodeVisitor([


### PR DESCRIPTION
The autoload section contains both directories and files depends on each type below:

- psr-0 (folder based)
- psr-4 (folder based)
- classmap (folders and files)
- files (files only)

See https://github.com/icanhazstring/composer-unused/pull/6 for more details!

`loadUsages` method contains 2 steps:

1. Looking for all directories and files of autoload composer section.
2. Getting usage packages:
   1. If both autoload directories and files are empty, raise an error 'Could not load paths from root package to scan.'
   2. Otherwise, return the listing of usage packages.

Therefore, I suggest using the new meaningful variables `$paths`, `$autoloadDirs` and `$autoloadFiles` for readable reason.

