### PR TITLE
Fix typo (usued => used)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Scanning files...
 
  1174/1174 [-----------------------------] 100%
 
-Found 13 usued and 0 unused packages
+Found 13 used and 0 unused packages
 
 Results
 -------

--- a/src/Command/UnusedCommand.php
+++ b/src/Command/UnusedCommand.php
@@ -94,7 +94,7 @@ class UnusedCommand extends BaseCommand
 
         $io->writeln(
             sprintf(
-                'Found <fg=green>%d usued</> and <fg=red>%d unused</> packages',
+                'Found <fg=green>%d used</> and <fg=red>%d unused</> packages',
                 count($usedPackages),
                 count($unusedPackages)
             )


### PR DESCRIPTION
Fixed a typo in the command output.