### PR TITLE
Feature: Change exitcode if unused packages are found

### DIFF
--- a/src/Command/UnusedCommand.php
+++ b/src/Command/UnusedCommand.php
@@ -77,6 +77,13 @@ class UnusedCommand extends BaseCommand
             'Provide one or more packages that should be ignored during scan',
             []
         );
+
+        $this->addOption(
+            'ignore-exit-code',
+            null,
+            InputOption::VALUE_NONE,
+            'Ignore exit codes so there are no "failure" exit codes'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -193,6 +200,10 @@ class UnusedCommand extends BaseCommand
 
         if ($this->composerIO->isDebug()) {
             $this->dumpLogs();
+        }
+
+        if ($packageLoaderResult->hasSkippedItems() && !$input->getOption('ignore-exit-code')) {
+            return 1;
         }
 
         return 0;

--- a/src/Command/UnusedCommand.php
+++ b/src/Command/UnusedCommand.php
@@ -115,14 +115,6 @@ class UnusedCommand extends BaseCommand
         }
 
         $usageLoaderResult = $usageLoader->load($composer, $this->io);
-
-        if (!$usageLoaderResult->hasItems()) {
-            $this->io->error('No usages could be found. Aborting.');
-            $this->dumpLogs();
-
-            return 1;
-        }
-
         $analyseUsageResult = $this->analyseUsages($packageLoaderResult->getItems(), $usageLoaderResult->getItems());
 
         /** @var PackageSubject[] $usedPackages */


### PR DESCRIPTION
The plugin will now always return an exit code > 0 if there are unused packages.
However, this will **NOT** change the behavior with real errors like:
- No found packages

Also we introduce a new cli argument `--ignore-exit-code`
If this is set, we ignore the unused packages and always return a clean `0` exit code.

Resolves #30 