### PR TITLE
fix(UnusedCommand): fail on unused packages

### DIFF
--- a/src/Command/UnusedCommand.php
+++ b/src/Command/UnusedCommand.php
@@ -179,7 +179,7 @@ class UnusedCommand extends BaseCommand
             );
         }
 
-        if ($packageLoaderResult->hasSkippedItems() && !$input->getOption('ignore-exit-code')) {
+        if (count($unusedPackages) > 0 && !$input->getOption('ignore-exit-code')) {
             return 1;
         }
 


### PR DESCRIPTION
Currently exitcode `1` is returned when packages are skipped. This should be the case when packages are actually unused.