### PR TITLE
[FEATURE] Adds typo3-cms-extension to allowed composer package types

### DIFF
--- a/src/Loader/Factory/PackageLoaderFactory.php
+++ b/src/Loader/Factory/PackageLoaderFactory.php
@@ -32,7 +32,7 @@ class PackageLoaderFactory implements FactoryInterface
                 new ExcludePackageFilter($options['excludes'] ?? []),
                 new NullConstraintFilter(),
                 new NullPackageFilter($repository),
-                new InvalidPackageTypeFilter($repository, ['library', 'symfony-bundle']),
+                new InvalidPackageTypeFilter($repository, ['library', 'symfony-bundle','typo3-cms-extension']),
                 new InvalidNamespaceFilter($repository)
             ]
         );


### PR DESCRIPTION
### All Submissions:

* [y] Does your PR have the correct target branch? (0.x for bugfix/feature of current release)
* [y] Have you followed the guidelines in our [Contributing document](../CONTRIBUTING.md)?
* [y] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?

### New Feature Submissions:

1. [y] Does your submission pass tests?
2. [y] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [y ] Have you added an explanation of what your changes do and why you'd like us to include them?

TYPO3 Extensions have type "typo3-cms-extension" which currently will not be evaluated with the `composer unused`. This PR adds "typo3-cms-extension" to allowed composer types, so that they get included in the scanning.

* [n] Have you written new tests for your core changes, as applicable?
* [y] Have you successfully ran tests with your changes locally?
