### PR TITLE
Invert package type validation

### DIFF
--- a/src/Loader/Factory/PackageLoaderFactory.php
+++ b/src/Loader/Factory/PackageLoaderFactory.php
@@ -32,7 +32,7 @@ class PackageLoaderFactory implements FactoryInterface
                 new ExcludePackageFilter($options['excludes'] ?? []),
                 new NullConstraintFilter(),
                 new NullPackageFilter($repository),
-                new InvalidPackageTypeFilter($repository, ['library', 'symfony-bundle', 'yii2-extension', 'typo3-cms-extension']),
+                new InvalidPackageTypeFilter($repository),
                 new InvalidNamespaceFilter($repository)
             ]
         );

--- a/src/Loader/Filter/InvalidPackageTypeFilter.php
+++ b/src/Loader/Filter/InvalidPackageTypeFilter.php
@@ -9,18 +9,15 @@ use Composer\Repository\RepositoryInterface;
 
 class InvalidPackageTypeFilter implements FilterInterface
 {
-    /** @var string[] */
-    private $validTypes;
+    private const INVALID_TYPES = ['project', 'metapackage', 'composer-plugin'];
     /** @var RepositoryInterface */
     private $repository;
 
     /**
      * @param RepositoryInterface $repository
-     * @param string[]            $validTypes
      */
-    public function __construct(RepositoryInterface $repository, array $validTypes)
+    public function __construct(RepositoryInterface $repository)
     {
-        $this->validTypes = $validTypes;
         $this->repository = $repository;
     }
 
@@ -35,7 +32,7 @@ class InvalidPackageTypeFilter implements FilterInterface
             return false;
         }
 
-        return !in_array($package->getType(), $this->validTypes, true);
+        return in_array($package->getType(), self::INVALID_TYPES, true);
     }
 
     public function getReason(): string

--- a/tests/Unit/Loader/Filter/InvalidPackageTypeFilterTest.php
+++ b/tests/Unit/Loader/Filter/InvalidPackageTypeFilterTest.php
@@ -57,7 +57,7 @@ class InvalidPackageTypeFilterTest extends TestCase
         $link->getTarget()->willReturn();
         $link->getConstraint()->willReturn();
 
-        $filter = new InvalidPackageTypeFilter($repository, ['library']);
+        $filter = new InvalidPackageTypeFilter($repository);
         $this->assertSame($expected, $filter->match($link->reveal()));
     }
 }


### PR DESCRIPTION
Instead of continuously adding valid types, we simply ignore those we
don't want. This way we allow more different kinds of composer package types.
