### PR TITLE
Fix short options usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Whether installing it as local or global dependency, run the command below insid
 
 ### Exclude folders and packages
 Sometimes you don't want to scan a certain directory or ignore a composer package while scanning.
-For this, you can provide the `--excludeDir|-xd` or the `--excludePackage|-xp` option.
+For this, you can provide the `--excludeDir|-d` or the `--excludePackage|-p` option.
 These options accept multiple values as this example:
 
     $ composer unused --excludeDir=config --excludePackage=symfony/console

--- a/src/Command/UnusedCommand.php
+++ b/src/Command/UnusedCommand.php
@@ -56,7 +56,7 @@ class UnusedCommand extends BaseCommand
 
         $this->addOption(
             'excludeDir',
-            'xd',
+            'd',
             InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED,
             'Provide one or more folders to exclude from usage scan',
             []
@@ -64,7 +64,7 @@ class UnusedCommand extends BaseCommand
 
         $this->addOption(
             'excludePackage',
-            'xp',
+            'p',
             InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED,
             'Provide one or more packages that should be ignored during scan',
             []


### PR DESCRIPTION
This will fix short options usage on excluding dirs or packages.
The previous implementation used a two character options which doesn't work
sind the `d` after the `-x` will be interpreted as the value for `-x`.