### PR TITLE
[WIP] Feature: PHAR Build

### DIFF
--- a/.docker/php7.3/Dockerfile
+++ b/.docker/php7.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-cli-stretch
+FROM php:7.3-cli-buster
 
 RUN apt-get update \
     && apt install -y \
@@ -12,7 +12,7 @@ RUN apt-get update \
     && docker-php-ext-install opcache \
     && rm -r /var/lib/apt/lists/*
 
-RUN pecl install xdebug-2.6.0 \
+RUN pecl install xdebug \
     	&& docker-php-ext-enable xdebug \
     	&& echo "error_reporting = E_ALL" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     	&& echo "display_startup_errors = On" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,8 @@ phpunit.xml export-ignore
 .github/ export-ignore
 art/ export-ignore
 tests/ export-ignore
+scoper.inc.php export-ignore
+box.json export-ignore
 
 CHANGELOG.md export-ignore
 CODE_OF_CONDUCT.md export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ composer.phar
 composer.lock
 cs-check.json
 .phpunit.result.cache
+/build/
+*.phar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.7.0] - TBA
+### Added
+- Added scoped `phar` support
+- Added `bin/composer-unused` as another entry point
+
+### Changed
+- Moved `composer/composer` into root requirements as its needed to run `bin/composer-unused`
+
 ## [0.6.2] - 2019-10-31
 ### Added
 - Added support to scan for unused php extensions [#33](https://github.com/icanhazstring/composer-unused/issues/33) thanks to [@marcelthole](https://github.com/marcelthole)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 # composer-unused
-A Composer Plugin to show unused Composer dependencies by scanning your code. 
+A Composer tool to show unused Composer dependencies by scanning your code. 
 
 Created by [Andreas Frömer](https://twitter.com/icanhazstring) and [contributors](https://github.com/icanhazstring/composer-unused/graphs/contributors), logo by [Caneco](https://twitter.com/caneco).
 
@@ -28,21 +28,34 @@ How do we check whether the provided *namespaces* of a package are used in our c
 
 ## Installation
 
+### PHP Archie (PHAR) (recommended)
+Grab the latest `composer-unused.phar` from the latest release:
+
+    $ curl -JOL https://github.com/icanhazstring/composer-unused/releases/latest/download/composer-unused.phar
+
 ### Global
 If you have a lot of projects and don't want to install this package per project, simply install it
 as a global dependency (e.g. on your CI):
 
     $ composer global require icanhazstring/composer-unused
 
-
 ### Local
 You can also install `composer-unused` as a local __development__ dependency:
 
     $ composer require --dev icanhazstring/composer-unused
 
-## Usage
+> :exclamation: Beware: Local (or global) requirement might lead to issues related to outdated or `replaced` dependencies and
+> `composer-unused` might not work as intended!
 
-Whether you installed it as a local or global dependency, run the command below inside your project directory to start a scan:
+## Usage
+Depending on the art of your installation the command might differ.
+
+### PHAR
+The `phar` archive is an executable and can be run directly in you project:
+    $ composer-unused.phar
+
+### Local/Global
+Having `composer-unused` as a local or global dependency you can run it as an composer-plugin:
 
     $ composer unused
 
@@ -52,8 +65,8 @@ Sometimes you don't want to scan a certain directory or ignore a Composer packag
 In these cases, you can provide the `--excludeDir` or the `--excludePackage` option.
 These options accept multiple values as shown next:
 
-    $ composer unused --excludeDir=config --excludePackage=symfony/console
-    $ composer unused \
+    $ composer-unused.phar --excludeDir=config --excludePackage=symfony/console
+    $ composer-unused.phar \
         --excludeDir=bin \
         --excludeDir=config \
         --excludePackage=symfony/assets \

--- a/bin/composer-unused
+++ b/bin/composer-unused
@@ -1,0 +1,5 @@
+#!/usr/bin/env php
+
+<?php
+
+echo 'test';

--- a/bin/composer-unused
+++ b/bin/composer-unused
@@ -2,4 +2,28 @@
 
 <?php
 
-echo 'test';
+use Composer\Composer;
+use Composer\Console\Application;
+use Composer\IO\IOInterface;
+use Icanhazstring\Composer\Unused\Command\UnusedCommand;
+use Symfony\Component\Console\Input\ArgvInput;
+
+(static function($argv) {
+    require __DIR__ . '/../vendor/autoload.php';
+
+    $container = require __DIR__ . '/../config/container.php';
+
+    $application = new Application();
+
+    $container->register(IOInterface::class, $application->getIO());
+    $container->register(Composer::class, $application->getComposer());
+
+    $application->add($container->get(UnusedCommand::class));
+
+    // Add 'unused' command if necessary
+    if (!isset($argv[1]) || $argv[1] !== 'unused') {
+        $argv = array_merge([$argv[0], 'unused'], array_slice($argv, 1));
+    }
+
+    $application->run(new ArgvInput($argv));
+})($argv);

--- a/box.json
+++ b/box.json
@@ -1,0 +1,5 @@
+{
+  "base-path": null,
+  "output": "build/composer-unused.phar",
+  "php-scoper": "scoper.inc.php"
+}

--- a/box.json
+++ b/box.json
@@ -1,5 +1,9 @@
 {
   "base-path": null,
   "output": "build/composer-unused.phar",
-  "php-scoper": "scoper.inc.php"
+  "php-scoper": "scoper.inc.php",
+  "files": [
+    "config/container.php",
+    "config/service_manager.php"
+  ]
 }

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "php": ">=7.1",
         "ext-json": "*",
         "composer-plugin-api": "^1.1.0",
+        "composer/composer": "^1.9",
         "nikic/php-parser": "^4.2",
         "psr/container": "^1.0",
         "psr/log": "^1.1",
@@ -27,7 +28,6 @@
     },
     "require-dev": {
         "ext-zend-opcache": "*",
-        "composer/composer": "^1.8",
         "jangregor/phpstan-prophecy": "^0.3.0",
         "phpstan/phpstan": "^0.11.4",
         "phpunit/phpunit": "^7.0",

--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,9 @@
         "test": "Use \"phpunit\" to run the tests. See phpunit.xml",
         "check": "Check the coding covention and run the tests"
     },
+    "bin": [
+        "bin/composer-unused"
+    ],
     "support": {
         "issues": "https://github.com/icanhazstring/composer-unused/issues",
         "source": "https://github.com/icanhazstring/composer-unused"

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Isolated\Symfony\Component\Finder\Finder;
+
+return [
+    'prefix' => 'ComposerUnused',
+
+    // By default when running php-scoper add-prefix, it will prefix all relevant code found in the current working
+    // directory. You can however define which files should be scoped by defining a collection of Finders in the
+    // following configuration key.
+    //
+    // For more see: https://github.com/humbug/php-scoper#finders-and-paths
+    'finders' => [
+        Finder::create()->files()->in('src'),
+        Finder::create()->files()->in('config'),
+        Finder::create()
+            ->files()
+            ->ignoreVCS(true)
+            ->notName('/LICENSE|.*\\.md|.*\\.dist|Makefile|composer\\.json|composer\\.lock/')
+            ->exclude([
+                'doc',
+                'test',
+                'test_old',
+                'tests',
+                'Tests',
+                'vendor-bin',
+            ])
+            ->in('vendor'),
+        Finder::create()->append([
+            'composer.json',
+        ]),
+    ],
+
+    // PHP-Scoper's goal is to make sure that all code for a project lies in a distinct PHP namespace. However, you
+    // may want to share a common API between the bundled code of your PHAR and the consumer code. For example if
+    // you have a PHPUnit PHAR with isolated code, you still want the PHAR to be able to understand the
+    // PHPUnit\Framework\TestCase class.
+    //
+    // A way to achieve this is by specifying a list of classes to not prefix with the following configuration key. Note
+    // that this does not work with functions or constants neither with classes belonging to the global namespace.
+    //
+    // Fore more see https://github.com/humbug/php-scoper#whitelist
+    'whitelist' => [
+    ],
+];

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -14,7 +14,6 @@ return [
     // For more see: https://github.com/humbug/php-scoper#finders-and-paths
     'finders' => [
         Finder::create()->files()->in('src'),
-        Finder::create()->files()->in('config'),
         Finder::create()
             ->files()
             ->ignoreVCS(true)
@@ -30,6 +29,8 @@ return [
             ->in('vendor'),
         Finder::create()->append([
             'composer.json',
+            'config/container.php',
+            'config/service_manager.php'
         ]),
     ],
 

--- a/src/UnusedPlugin.php
+++ b/src/UnusedPlugin.php
@@ -14,7 +14,7 @@ use Icanhazstring\Composer\Unused\Di\ServiceContainer;
 
 final class UnusedPlugin implements Plugin\PluginInterface, Plugin\Capable, Plugin\Capability\CommandProvider
 {
-    public const VERSION = '0.5.1';
+    public const VERSION = '0.7.0';
 
     /** @var ServiceContainer */
     private $container;


### PR DESCRIPTION
This relates to #61 and #62 

The following changes should be made:
- [x] Add a build process to package an executable `composer-unused.phar`
- [x] The package namespaces should be scoped to avoid interference with consumer namespaces
- [x] Add `bin/composer-unused` executable as `main` entry point
- [x] `bin/composer-unused` should work as simple `Composer\Console` application
- [x] Update `README.md` with new usage
  - [x] Remove mention of "composer plugin" as it is a merely a tool used within composer scope
  - [x] Add notice to `composer global require` that it is not recommended
  - [x] Add PHAR usage installation 
- [x] Update `CHANGELOG.md`